### PR TITLE
Implement CORS policy to allow requests from the

### DIFF
--- a/logify-backend/config/settings.py
+++ b/logify-backend/config/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "corsheaders",
     "apps.accounts.apps.AccountsConfig",
     "apps.academics.apps.AcademicsConfig",
     "apps.evaluations.apps.EvaluationsConfig",
@@ -62,6 +63,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -146,3 +148,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
 
 STATIC_URL = "static/"
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+]

--- a/logify-backend/requirements-dev.txt
+++ b/logify-backend/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-django
 djangorestframework
 testcontainers[postgresql]
 psycopg2-binary
+django-cors-headers


### PR DESCRIPTION
frontend application running on localhost:3000. This involves adding the 'corsheaders' package to the installed apps, including the CORS middleware, and specifying the allowed origins in the settings.py file. Additionally, the 'django-cors-headers' package is added to the development requirements to ensure it is available during development.