### PR TITLE
Feature/109 create shared frontend api client

### DIFF
--- a/logify-backend/apps/academics/urls.py
+++ b/logify-backend/apps/academics/urls.py
@@ -12,29 +12,27 @@ from .views import (
 )
 
 urlpatterns = [
-    path("academics/institutions/", InstitutionsListView.as_view(), name="institutions-list"),
+    path("institutions/", InstitutionsListView.as_view(), name="institutions-list"),
     path(
-        "academics/institutions/<int:pk>/",
+        "institutions/<int:pk>/",
         InstitutionsDetailView.as_view(),
         name="institutions-detail",
     ),
-    path("academics/departments/", DepartmentsListView.as_view(), name="departments-list"),
+    path("departments/", DepartmentsListView.as_view(), name="departments-list"),
     path(
-        "academics/departments/<int:pk>/",
+        "departments/<int:pk>/",
         DepartmentsDetailView.as_view(),
         name="departments-detail",
     ),
     path(
-        "academics/institutions/<int:institution_id>/departments/",
+        "institutions/<int:institution_id>/departments/",
         InstitutionDepartmentsListView.as_view(),
         name="institution-departments-list",
     ),
-    path("academics/programmes/", ProgrammesListView.as_view(), name="programmes-list"),
+    path("programmes/", ProgrammesListView.as_view(), name="programmes-list"),
+    path("programmes/<int:pk>/", ProgrammesDetailView.as_view(), name="programmes-detail"),
     path(
-        "academics/programmes/<int:pk>/", ProgrammesDetailView.as_view(), name="programmes-detail"
-    ),
-    path(
-        "academics/departments/<int:department_id>/programmes/",
+        "departments/<int:department_id>/programmes/",
         DepartmentProgrammesListView.as_view(),
         name="department-programmes-list",
     ),

--- a/logify-frontend/src/config/api.js
+++ b/logify-frontend/src/config/api.js
@@ -68,6 +68,16 @@ export const api = {
         method: "POST",
         body: JSON.stringify(data),
       }),
+    studentRequestOTP: (data) =>
+      apiRequest("/v1/auth/student/request-otp/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    studentVerifyOTP: (data) =>
+      apiRequest("/v1/auth/student/verify-otp/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
   },
 
   accounts: {

--- a/logify-frontend/src/config/api.js
+++ b/logify-frontend/src/config/api.js
@@ -70,18 +70,266 @@ export const api = {
       }),
   },
 
+  accounts: {
+    approveSupervisor: (applicationId, data) =>
+      apiRequest(`/v1/accounts/supervisor/approve/${applicationId}/`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+  },
+
   academics: {
     getInstitutions: () => apiRequest("/v1/academics/institutions"),
     getInstitution: (id) => apiRequest(`/v1/academics/institutions/${id}/`),
 
     getDepartments: () => apiRequest("/v1/academics/departments/"),
-    getDepartment: (id) => apiRequest(`/v1/academics/departments/${id}`),
+    getDepartment: (id) => apiRequest(`/v1/academics/departments/${id}/`),
     getInstitutionDepartments: (institutionId) =>
       apiRequest(`/v1/academics/institutions/${institutionId}/departments/`),
 
     getProgrammes: () => apiRequest("/v1/academics/programmes/"),
-    getProgramme: (id) => apiRequest(`/v1/academics/programmes/${id}`),
+    getProgramme: (id) => apiRequest(`/v1/academics/programmes/${id}/`),
     getDepartmentProgrammes: (departmentId) =>
       apiRequest(`/v1/academics/departments/${departmentId}/programmes/`),
+  },
+
+  placements: {
+    getPlacements: () => apiRequest("/v1/placements/placements/"),
+    getPlacement: (id) => apiRequest(`/v1/placements/placements/${id}/`),
+    createPlacement: (data) =>
+      apiRequest(`/v1/placements/placements/`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    updatePlacement: (id, data) =>
+      apiRequest(`/v1/placements/placements/${id}/`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    patchPlacement: (id, data) =>
+      apiRequest(`/v1/placements/placements/${id}/`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+
+    submitPlacement: (id) =>
+      apiRequest(`/v1/placements/placements/${id}/submit/`, { method: "POST" }),
+    approvePlacement: (id) =>
+      apiRequest(`/v1/placements/placements/${id}/approve/`, {
+        method: "POST",
+      }),
+    rejectPlacement: (id) =>
+      apiRequest(`/v1/placements/placements/${id}/reject/`, { method: "POST" }),
+    activatePlacement: (id) =>
+      apiRequest(`/v1/placements/placements/${id}/activate/`, {
+        method: "POST",
+      }),
+    completePlacement: (id) =>
+      apiRequest(`/v1/placements/placements/${id}/complete/`, {
+        method: "POST",
+      }),
+    cancelPlacement: (id) =>
+      apiRequest(`/v1/placements/placements/${id}/cancel/`, { method: "POST" }),
+
+    assignAcademicSupervisor: (id, data) =>
+      apiRequest(
+        `/v1/placements/placements/${id}/assign-academic-supervisor/`,
+        { method: "POST", body: JSON.stringify(data) },
+      ),
+    assignWorkplaceSupervisor: (id, data) =>
+      apiRequest(
+        `/v1/placements/placements/${id}/assign-workplace-supervisor/`,
+        { method: "POST", body: JSON.stringify(data) },
+      ),
+  },
+
+  logbook: {
+    createWeeklyLog: (data) =>
+      apiRequest("/v1/logbook/create_weekly_log/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    updateWeeklyLog: (id, data) =>
+      apiRequest(`/v1/logbook/update_weekly_log/${id}/`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    patchWeeklyLog: (id, data) =>
+      apiRequest(`/v1/logbook/update_weekly_log/${id}/`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+    submitWeeklyLog: (id) =>
+      apiRequest(`/v1/logbook/submit_weekly_log/${id}/`, { method: "POST" }),
+    approveWeeklyLog: (id) =>
+      apiRequest(`/v1/logbook/approve_weekly_log/${id}/`, { method: "POST" }),
+    rejectWeeklyLog: (id) =>
+      apiRequest(`/v1/logbook/reject_weekly_log/${id}/`, { method: "POST" }),
+    requestChangesWeeklyLog: (id, data) =>
+      apiRequest(`/v1/logbook/request_changes_weekly_log/${id}/`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+
+    getWeeklyLogs: () => apiRequest("/v1/logbook/weekly_logs/"),
+    getWeeklyLog: (id) => apiRequest(`/v1/logbook/weekly_log_status/${id}/`),
+    getWeeklyLogHistory: () => apiRequest(`/v1/logbook/history/`),
+    deleteWeeklyLog: (id) =>
+      apiRequest(`/v1/logbook/delete_weekly_log/${id}/`, { method: "DELETE" }),
+  },
+
+  organizations: {
+    getOrganizations: () => apiRequest("/v1/organizations/createOrganization/"),
+    getOrganization: (id) =>
+      apiRequest(`/v1/organizations/getOrganization/${id}/`),
+    createOrganization: (data) =>
+      apiRequest("/v1/organizations/createOrganization/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    updateOrganization: (id, data) =>
+      apiRequest(`/v1/organizations/getOrganization/${id}/`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    patchOrganization: (id, data) =>
+      apiRequest(`/v1/organizations/getOrganization/${id}/`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+    deleteOrganization: (id) =>
+      apiRequest(`/v1/organizations/getOrganization/${id}/`, {
+        method: "DELETE",
+      }),
+  },
+
+  reports: {
+    getReport: (studentId, params = {}) => {
+      const queryString = new URLSearchParams(params).toString();
+      const endpoint = `/v1/reports/weekly_logs_report/${studentId}/${queryString ? "?" + queryString : ""}`;
+      return apiRequest(endpoint);
+    },
+  },
+
+  evaluations: {
+    getResults: () => apiRequest("/v1/evaluations/results/"),
+    getResult: (id) => apiRequest(`/v1/evaluations/results/${id}/`),
+
+    getRubrics: () => apiRequest("/v1/evaluations/rubrics/"),
+    getRubric: (id) => apiRequest(`/v1/evaluations/rubrics/${id}/`),
+    createRubric: (data) =>
+      apiRequest("/v1/evaluations/rubrics/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    updateRubric: (id, data) =>
+      apiRequest(`/v1/evaluations/rubrics/${id}/`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    patchRubric: (id, data) =>
+      apiRequest(`/v1/evaluations/rubrics/${id}/`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+    deleteRubric: (id) =>
+      apiRequest(`/v1/evaluations/rubrics/${id}/`, { method: "DELETE" }),
+
+    getCriteria: () => apiRequest("/v1/evaluations/criteria/"),
+    getCriterion: (id) => apiRequest(`/v1/evaluations/criteria/${id}/`),
+    createCriterion: (data) =>
+      apiRequest("/v1/evaluations/criteria/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    updateCriterion: (id, data) =>
+      apiRequest(`/v1/evaluations/criteria/${id}/`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    deleteCriterion: (id) =>
+      apiRequest(`/v1/evaluations/criteria/${id}/`, { method: "DELETE" }),
+
+    getEvaluations: () => apiRequest("/v1/evaluations/evaluations/"),
+    getEvaluation: (id) => apiRequest(`/v1/evaluations/evaluations/${id}/`),
+    createEvaluation: (data) =>
+      apiRequest("/v1/evaluations/evaluations/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    updateEvaluation: (id, data) =>
+      apiRequest(`/v1/evaluations/evaluations/${id}/`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    patchEvaluation: (id, data) =>
+      apiRequest(`/v1/evaluations/evaluations/${id}/`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+    deleteEvaluation: (id) =>
+      apiRequest(`/v1/evaluations/evaluations/${id}/`, { method: "DELETE" }),
+
+    getScores: () => apiRequest("/v1/evaluations/scores/"),
+    getScore: (id) => apiRequest(`/v1/evaluations/scores/${id}/`),
+    createScore: (data) =>
+      apiRequest("/v1/evaluations/scores/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    updateScore: (id, data) =>
+      apiRequest(`/v1/evaluations/scores/${id}/`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    patchScore: (id, data) =>
+      apiRequest(`/v1/evaluations/scores/${id}/`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+    deleteScore: (id) =>
+      apiRequest(`/v1/evaluations/scores/${id}/`, { method: "DELETE" }),
+  },
+
+  registry: {
+    getStudents: () => apiRequest("/v1/registry/students/"),
+    getStudent: (id) => apiRequest(`/v1/registry/students/${id}/`),
+    createStudent: (data) =>
+      apiRequest("/v1/registry/students/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    updateStudent: (id, data) =>
+      apiRequest(`/v1/registry/students/${id}/`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    patchStudent: (id, data) =>
+      apiRequest(`/v1/registry/students/${id}/`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
+    deleteStudent: (id) =>
+      apiRequest(`/v1/registry/students/${id}/`, { method: "DELETE" }),
+
+    getRegistrationAttempts: () =>
+      apiRequest("/v1/registry/registration-attempts/"),
+    requestOTP: (data) =>
+      apiRequest("/v1/registry/registration-attempts/request_otp/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    verifyOTP: (data) =>
+      apiRequest("/v1/registry/registration-attempts/verify_otp/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+
+    importStudents: (data) =>
+      apiRequest("/v1/registry/import-students/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    exportStudents: () => apiRequest("/v1/registry/export-students/"),
   },
 };

--- a/logify-frontend/src/config/api.js
+++ b/logify-frontend/src/config/api.js
@@ -1,0 +1,87 @@
+import { getSession } from "@/pages/auth/authStore";
+
+const API_BASE_URL = import.meta.env.VITE_BACKEND_URL;
+
+const getAuthHeaders = () => {
+  const session = getSession();
+  return session
+    ? {
+        Authorization: `${session.tokenType} ${session.token}`,
+        "Content-Type": "application/json",
+      }
+    : {
+        "Content-Type": "application/json",
+      };
+};
+
+const apiRequest = async (endpoint, options = {}) => {
+  const url = `${API_BASE_URL}${endpoint}`;
+  const config = {
+    ...options,
+    headers: {
+      ...getAuthHeaders(),
+      ...options.headers,
+    },
+  };
+  try {
+    const response = await fetch(url, config);
+    if (!response.ok) {
+      const errorData = await response.text();
+
+      let errorMessage = `HTTP ${response.status}`;
+      try {
+        const parsed = JSON.parse(errorData);
+        errorMessage = parsed.detail || parsed.message || errorData;
+      } catch {
+        errorMessage = errorData;
+      }
+      throw new Error(errorMessage);
+    }
+    const text = await response.text();
+    return text ? JSON.parse(text) : null;
+  } catch (err) {
+    console.error("API request failed:", err);
+    throw err;
+  }
+};
+
+export const api = {
+  auth: {
+    login: (data) =>
+      apiRequest("/v1/auth/login/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    logout: (data) =>
+      apiRequest("/v1/auth/logout/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    refresh: (data) =>
+      apiRequest("/v1/auth/refresh/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    me: () => apiRequest("/v1/auth/me/"),
+    supervisorSignup: (data) =>
+      apiRequest("/v1/auth/supervisor/signup/", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+  },
+
+  academics: {
+    getInstitutions: () => apiRequest("/v1/academics/institutions"),
+    getInstitution: (id) => apiRequest(`/v1/academics/institutions/${id}/`),
+
+    getDepartments: () => apiRequest("/v1/academics/departments/"),
+    getDepartment: (id) => apiRequest(`/v1/academics/departments/${id}`),
+    getInstitutionDepartments: (institutionId) =>
+      apiRequest(`/v1/academics/institutions/${institutionId}/departments/`),
+
+    getProgrammes: () => apiRequest("/v1/academics/programmes/"),
+    getProgramme: (id) => apiRequest(`/v1/academics/programmes/${id}`),
+    getDepartmentProgrammes: (departmentId) =>
+      apiRequest(`/v1/academics/departments/${departmentId}/programmes/`),
+  },
+};

--- a/logify-frontend/src/config/api.js
+++ b/logify-frontend/src/config/api.js
@@ -1,6 +1,17 @@
-import { getSession } from "@/pages/auth/authStore";
-
 const API_BASE_URL = import.meta.env.VITE_BACKEND_URL;
+
+const SESSION_STORAGE_KEY = "logify-auth-session";
+
+const getSession = () => {
+  const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    window.localStorage.removeItem(SESSION_STORAGE_KEY);
+    return null;
+  }
+};
 
 const getAuthHeaders = () => {
   const session = getSession();

--- a/logify-frontend/src/pages/auth/authStore.js
+++ b/logify-frontend/src/pages/auth/authStore.js
@@ -1,3 +1,18 @@
+// Authentication Store - Production Ready
+//
+// This module handles user authentication with support for both:
+// 1. Mock authentication (development/testing) - uses localStorage
+// 2. Real API authentication (production) - connects to Django backend
+//
+// To toggle between modes, set VITE_USE_MOCK_AUTH=true in .env for development
+// Leave unset or set to false for production API integration
+
+import { api } from "../../config/api.js";
+
+// Flag to toggle between mock and real authentication
+const USE_MOCK_AUTH = import.meta.env.VITE_USE_MOCK_AUTH === "true";
+
+// Mock data for development only - NOT used in production
 const USERS_STORAGE_KEY = "logify-auth-users";
 const SESSION_STORAGE_KEY = "logify-auth-session";
 
@@ -90,6 +105,52 @@ export function clearSession() {
   window.localStorage.removeItem(SESSION_STORAGE_KEY);
 }
 
+export async function logout() {
+  const session = getSession();
+  if (session?.refreshToken) {
+    try {
+      // Call backend logout endpoint if available
+      await api.auth.logout({ refresh: session.refreshToken });
+    } catch (error) {
+      // Ignore logout errors - session will be cleared locally anyway
+      console.warn("Backend logout failed:", error);
+    }
+  }
+
+  clearSession();
+  return { ok: true };
+}
+
+export async function refreshToken() {
+  const session = getSession();
+  if (!session?.refreshToken) {
+    throw new Error("No refresh token available");
+  }
+
+  try {
+    const response = await api.auth.refresh({ refresh: session.refreshToken });
+
+    const updatedSession = {
+      ...session,
+      token: response.access,
+      refreshToken: response.refresh || session.refreshToken,
+    };
+
+    window.localStorage.setItem(
+      SESSION_STORAGE_KEY,
+      JSON.stringify(updatedSession),
+    );
+
+    return { ok: true, session: updatedSession };
+  } catch (error) {
+    // If refresh fails, clear session
+    clearSession();
+    throw new Error(
+      `Token refresh failed: ${error.message || "Session expired. Please log in again."}`,
+    );
+  }
+}
+
 function roleHome(role) {
   if (role === "internship_admin") {
     return "/admin";
@@ -103,7 +164,40 @@ function roleHome(role) {
   return "/";
 }
 
-export function authenticate({ email, password }) {
+export async function authenticate({ email, password }) {
+  if (USE_MOCK_AUTH) {
+    // Use existing mock authentication for development
+    return authenticateMock({ email, password });
+  }
+
+  // Use real backend API for production
+  try {
+    const response = await api.auth.login({ email, password });
+
+    const session = {
+      token: response.access,
+      refreshToken: response.refresh,
+      user: response.user,
+      tokenType: "Bearer",
+    };
+
+    window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+
+    return {
+      ok: true,
+      session,
+      redirectPath: roleHome(response.user.role),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message || "Login failed. Please check your credentials.",
+    };
+  }
+}
+
+// Keep the original mock function for development
+function authenticateMock({ email, password }) {
   const users = readUsers();
   const normalized = normalizeEmail(email);
   const user = users.find((item) => item.email === normalized);
@@ -178,6 +272,16 @@ export function validateCommonSignupFields({
 }
 
 export function registerAdmin({ fullName, email, password }) {
+  // Admin registration is handled through Django admin interface
+  // This function is for development/testing only
+  if (!USE_MOCK_AUTH) {
+    return {
+      ok: false,
+      error:
+        "Admin registration is not available through the API. Please contact system administrator or use Django admin.",
+    };
+  }
+
   const users = readUsers();
   const normalizedEmail = normalizeEmail(email);
 
@@ -210,7 +314,52 @@ export function registerAdmin({ fullName, email, password }) {
   return { ok: true };
 }
 
-export function registerSupervisor({
+export async function registerSupervisor({
+  fullName,
+  email,
+  password,
+  role,
+  institutionOrOrganization,
+}) {
+  if (USE_MOCK_AUTH) {
+    // Use existing mock registration for development
+    return registerSupervisorMock({
+      fullName,
+      email,
+      password,
+      role,
+      institutionOrOrganization,
+    });
+  }
+
+  // Use real backend API for production
+  try {
+    const signupData = {
+      email,
+      password,
+      first_name: fullName.split(" ")[0],
+      last_name: fullName.split(" ").slice(1).join(" "),
+      role,
+      phone: "", // Add phone field if needed
+    };
+
+    await api.auth.supervisorSignup(signupData);
+
+    return {
+      ok: true,
+      message:
+        "Supervisor application submitted successfully. Your account is pending approval.",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message || "Registration failed. Please try again.",
+    };
+  }
+}
+
+// Keep the original mock function for development
+function registerSupervisorMock({
   fullName,
   email,
   password,
@@ -253,6 +402,143 @@ export function registerSupervisor({
     role,
     institutionOrOrganization: institutionOrOrganization.trim(),
     status: "pending_approval",
+  };
+
+  writeUsers([...users, newUser]);
+  return { ok: true };
+}
+
+export async function registerStudent({
+  fullName,
+  email,
+  password,
+  studentId,
+  program,
+  yearOfStudy,
+}) {
+  if (USE_MOCK_AUTH) {
+    // Use existing mock registration for development
+    return registerStudentMock({
+      fullName,
+      email,
+      password,
+      studentId,
+      program,
+      yearOfStudy,
+    });
+  }
+
+  // Use real backend API for production - OTP-based registration
+  try {
+    // First request OTP
+    await api.auth.studentRequestOTP({ email });
+
+    return {
+      ok: true,
+      requiresOTP: true,
+      message:
+        "OTP sent to your email. Please verify to complete registration.",
+      registrationData: {
+        fullName,
+        email,
+        password,
+        studentId,
+        program,
+        yearOfStudy,
+      },
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message || "Failed to send OTP. Please try again.",
+    };
+  }
+}
+
+export async function verifyStudentOTP({ email, otp, registrationData }) {
+  if (USE_MOCK_AUTH) {
+    // For mock mode, just complete registration
+    return registerStudentMock(registrationData);
+  }
+
+  // Use real backend API for production
+  try {
+    const signupData = {
+      email,
+      otp,
+      password: registrationData.password,
+      first_name: registrationData.fullName.split(" ")[0],
+      last_name: registrationData.fullName.split(" ").slice(1).join(" "),
+      student_id: registrationData.studentId,
+      program: registrationData.program,
+      year_of_study: registrationData.yearOfStudy,
+    };
+
+    await api.auth.studentVerifyOTP(signupData);
+
+    return {
+      ok: true,
+      message: "Student registration successful. Welcome to Logify!",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message || "OTP verification failed. Please try again.",
+    };
+  }
+}
+
+// Keep the original mock function for development
+function registerStudentMock({
+  fullName,
+  email,
+  password,
+  studentId,
+  program,
+  yearOfStudy,
+}) {
+  const users = readUsers();
+  const normalizedEmail = normalizeEmail(email);
+
+  if (users.some((user) => user.email === normalizedEmail)) {
+    return {
+      ok: false,
+      error:
+        "This email is already registered. If you are a returning user, use Login instead.",
+    };
+  }
+
+  if (!studentId?.trim()) {
+    return {
+      ok: false,
+      error: "Student ID is required.",
+    };
+  }
+
+  if (!program?.trim()) {
+    return {
+      ok: false,
+      error: "Program is required.",
+    };
+  }
+
+  if (!yearOfStudy) {
+    return {
+      ok: false,
+      error: "Year of study is required.",
+    };
+  }
+
+  const newUser = {
+    id: Date.now(),
+    fullName: fullName.trim(),
+    email: normalizedEmail,
+    password,
+    role: "student",
+    studentId: studentId.trim(),
+    program: program.trim(),
+    yearOfStudy: parseInt(yearOfStudy),
+    status: "approved", // Students are auto-approved
   };
 
   writeUsers([...users, newUser]);


### PR DESCRIPTION
- [x] Understand circular import: `api.js` imports `getSession` from `authStore.js`, and `authStore.js` imports `api` from `api.js`
- [x] Fix `api.js` to read session from localStorage directly (removing the authStore import) — uses the same key `"logify-auth-session"` and identical parse/clear logic as `getSession()`
- [x] Verify storage key values match between both files
- [x] Confirm one-way dependency: only `authStore.js` → `api.js` remains